### PR TITLE
Allow blank nodes and always use nodes instead of strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "es6-promise": "^4.0.5",
     "immutable": "^3.8.1",
     "jsonld": "^0.4.11",
-    "link-lib": "^1.0.0-beta6",
+    "link-lib": "^1.0.0-beta7",
     "prop-types": "^15.6.0",
     "rdflib": "^0.16.3",
     "react": "^16.1.0",

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -2,14 +2,16 @@ import LinkedRenderStore from 'link-lib';
 import PropTypes from 'prop-types';
 import rdf from 'rdflib';
 
+export const nodeType = PropTypes.oneOfType([
+  PropTypes.instanceOf(rdf.NamedNode),
+  PropTypes.instanceOf(rdf.BlankNode),
+]);
+
 export const labelType = PropTypes.oneOfType([
   PropTypes.instanceOf(rdf.NamedNode),
   PropTypes.arrayOf(PropTypes.instanceOf(rdf.NamedNode)),
 ]);
-export const linkedPropType = PropTypes.oneOfType([
-  PropTypes.object,
-  PropTypes.string,
-]);
+export const linkedPropType = nodeType;
 export const lrsType = PropTypes.instanceOf(LinkedRenderStore);
-export const subjectType = PropTypes.instanceOf(rdf.NamedNode);
-export const topologyType = PropTypes.instanceOf(rdf.NamedNode);
+export const subjectType = nodeType;
+export const topologyType = nodeType;

--- a/src/react/components/Property.js
+++ b/src/react/components/Property.js
@@ -24,6 +24,8 @@ const defaultProps = {
   forceRender: false,
 };
 
+const nodeTypes = ['NamedNode', 'BlankNode'];
+
 export function getLinkedObjectClass(props, { topology, linkedRenderStore }) {
   return linkedRenderStore.getRenderClassForProperty(
     allRDFValues(linkedRenderStore.tryEntity(props.subject), defaultNS.rdf('type'), true),
@@ -46,10 +48,10 @@ export const PropertyComp = (props, context) => {
   }
   const Klass = getLinkedObjectClass(props, context);
   if (Klass) {
-    return React.createElement(Klass, { linkedProp: obj, ...props });
+    return React.createElement(Klass, { linkedProp: objRaw, ...props });
   }
-  if (typeof objRaw !== 'undefined' && objRaw.termType === 'NamedNode') {
-    return React.createElement(LOC, { object: objRaw.value, ...props });
+  if (typeof objRaw !== 'undefined' && nodeTypes.includes(objRaw.termType)) {
+    return React.createElement(LOC, { object: objRaw, ...props });
   }
   if (obj) {
     return React.createElement('div', null, obj);

--- a/src/react/components/PropertyBase.js
+++ b/src/react/components/PropertyBase.js
@@ -55,11 +55,7 @@ export function getLinkedObjectProperty(property, subject, linkedRenderStore, te
   if (rawProp === undefined) {
     return undefined;
   }
-  const val = getPropBestLang(rawProp);
-
-  if (term) return val;
-  return val && val.constructor !== Object &&
-    (val.href || val.value || val.toString());
+  return getPropBestLang(rawProp);
 }
 
 export const contextTypes = {
@@ -104,7 +100,7 @@ class PropertyBase extends React.Component {
       'span',
       null,
       'PropBase: ',
-      this.getLinkedObjectProperty(),
+      this.getLinkedObjectProperty().value,
     );
   }
 }

--- a/src/redux/LinkedObjectContainer.js
+++ b/src/redux/LinkedObjectContainer.js
@@ -89,7 +89,7 @@ class LinkedObjectContainer extends Component {
 
   subject(props = this.props) {
     if (!nodeTypes.includes(props.object.termType)) {
-      throw new Error('[LOC] Object must be a node');
+      throw new Error(`[LOC] Object must be a node (was '${typeof props.object}[${props.object}]')`);
     }
     return props.object;
   }
@@ -173,7 +173,7 @@ export default connect(
       throw new Error('[LOC] an object must be given');
     }
     if (!nodeTypes.includes(subject.termType)) {
-      throw new Error('[LOC] Object must be a node');
+      throw new Error(`[LOC] Object must be a node (was '${typeof subject}')`);
     }
     return {
       version: linkedObjectVersionByIRI(state, subject),

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -6,7 +6,7 @@ import { generateContext } from './utilities';
 const exNS = rdf.Namespace('http://example.org/');
 const { schema } = defaultNS;
 
-const context = (iri, lrs, store) => generateContext({
+export const context = (iri, lrs, store) => generateContext({
   linkedRenderStore: lrs || true,
   subject: iri,
   store: store || false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2805,9 +2805,9 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-link-lib@^1.0.0-beta6:
-  version "1.0.0-beta6"
-  resolved "https://registry.yarnpkg.com/link-lib/-/link-lib-1.0.0-beta6.tgz#ac2175503c8ea87fb252a36a5230aaa662bd7b8a"
+link-lib@^1.0.0-beta7:
+  version "1.0.0-beta7"
+  resolved "https://registry.yarnpkg.com/link-lib/-/link-lib-1.0.0-beta7.tgz#36f3a22ba80f17b69807524cedae1938a898cb5a"
   dependencies:
     jsonld "^0.4.11"
     ml-disjoint-set "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1517,13 +1517,9 @@ detect-libc@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.2.tgz#71ad5d204bf17a6a6ca8f450c61454066ef461e1"
 
-diff@3.3.1:
+diff@3.3.1, diff@^3.1.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.1.tgz#aa8567a6eed03c531fc89d3f711cd0e5259dec75"
-
-diff@^3.1.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
 
 diffie-hellman@^5.0.0:
   version "5.0.2"
@@ -1580,16 +1576,9 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
-domutils@1.5.1:
+domutils@1.5.1, domutils@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
-  dependencies:
-    dom-serializer "0"
-    domelementtype "1"
-
-domutils@^1.5.1:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.6.2.tgz#1958cc0b4c9426e9ed367fb1c8e854891b0fa3ff"
   dependencies:
     dom-serializer "0"
     domelementtype "1"
@@ -2816,7 +2805,7 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-link-lib@^1.0.0-beta5:
+link-lib@^1.0.0-beta6:
   version "1.0.0-beta6"
   resolved "https://registry.yarnpkg.com/link-lib/-/link-lib-1.0.0-beta6.tgz#ac2175503c8ea87fb252a36a5230aaa662bd7b8a"
   dependencies:
@@ -4116,7 +4105,7 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-supports-color@4.4.0:
+supports-color@4.4.0, supports-color@^4.2.1:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
   dependencies:
@@ -4125,12 +4114,6 @@ supports-color@4.4.0:
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
-
-supports-color@^4.2.1:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
-  dependencies:
-    has-flag "^2.0.0"
 
 symbol-observable@^1.0.3:
   version "1.0.4"


### PR DESCRIPTION
Add support for BlankNodes.
Make sure that all references passed to LOC and properties are Nodes. String are no longer supported.